### PR TITLE
Use deobfCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ In your build.gradle, add:
 		}
 	}
 
-	dependencies{
-		compile "signals:Signals-1.12.2:1.1.0-1:userdev"
+	dependencies {
+		deobfCompile "signals:Signals-1.12.2:1.1.0-1:universal"
 	}
 
 It should be clear that the version number used in the 'compile' is an example, to see which versions you can use, go to http://maven.k-4u.nl/signals/


### PR DESCRIPTION
Instead of using the deobf version from your particular set of MCP mappings,
use the SRG version, and let deobfCompile turn it into whatever set of
mappings are used in the project this is used from. This stops crashes such as
ones of the type seen in CyclopsMC/IntegratedDynamics-Compat#4.