### PR TITLE
Don't generate chunks when exploring rail network

### DIFF
--- a/src/com/minemaarten/signals/rail/network/mc/NetworkObjectProvider.java
+++ b/src/com/minemaarten/signals/rail/network/mc/NetworkObjectProvider.java
@@ -31,6 +31,10 @@ public class NetworkObjectProvider implements INetworkObjectProvider<MCPos>{
 
     public NetworkObject<MCPos> provide(World world, BlockPos pos){
         MCPos mcPos = new MCPos(world.provider.getDimension(), pos);
+        if (!world.isChunkGeneratedAt(pos.getX() >> 4, pos.getZ() >> 4)) {
+            return null;
+        }
+    
         IBlockState state = world.getBlockState(pos);
         IRail rail = RailManager.getInstance().getRail(world, pos, state);
         if(rail != null) {


### PR DESCRIPTION
In a related issue to #63, I've found that Signals still doesn't play well with worldgen rail networks. Specifically, when exploring the network, Signals will generate chunks to explore the network. In Lost Cities worlds, depending on configuration, the subway rail network can span the entire world. This means that the rail network exploration can theoretically never end.

As an example, I placed a signal next to a rail in my world, and realized my mistake quickly when the server ground to halt. Afterwards, I saw that it had explored a single rail line out to 16 kilometers away from spawn, generating chunks in a line along the way. (The farthest we have explored is out to 5 km.) At the end of this rail is a single missing track, part of random damage, suggesting that it *would* have kept exploring until the server crashed if able.

![signals-railgen-bug](https://user-images.githubusercontent.com/25140955/44307243-949a5700-a364-11e8-94f9-1e9ff31cce0d.png)

Because of this, I suggest checking to see if a chunk is generated before probing a block for rail network objects. This will prevent Signals from generating chunks while exploring networks. I really don't think there's any reason for Signals to generate chunks at any rate, since world gen rail networks are rarely appropriately signaled.

I'm not really familiar with the code base, so I'm not sure if this is the only change required. I also haven't set up a build environment for this mod, so this change is untested, but it's a very simple change, so I don't think it should be hard to check.

